### PR TITLE
ci: add workflow to push Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,54 @@
+name: docker-push
+
+on:
+  push:
+    branches: ["main"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary
- #39 で GHCR を採用したので、main へのマージ（push）時に Docker イメージをビルドして `ghcr.io/${{ github.repository }}` へ push する workflow (`.github/workflows/docker-push.yml`) を追加
- イメージには `latest` タグとコミット sha タグを付与
- ビルド成果物の provenance attestation も生成し、GHCR に登録

Closes #42

## Test plan
- [ ] YAML構文チェック（ローカルで `yaml.safe_load` により検証済み）
- [ ] main にマージ後、Actions タブで `docker-push` ワークフローが成功し、`ghcr.io/sut103/7dayspoll-for-discord` にイメージが push されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lxikntq3NmfTeswHAPWDwY)_