### PR TITLE
Add unit tests for this repository and wire go test into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: app/go.mod
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./... -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: test
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
         working-directory: app
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: app/go.mod
       - name: Vet
         run: go vet ./...
       - name: Test
-        run: go test ./... -v
+        run: go test ./... -race -v

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ The classic embed-based poll with emoji reactions is still available as `/poll-c
    go run .
    ```
 
+### Running Tests
+
+```bash
+cd app
+go test ./...
+```
+
 ## Building with Docker
 
 To build the Docker image:

--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -22,15 +22,36 @@ func NewBot(token string) *Bot {
 	}
 }
 
+type commandKind int
+
+const (
+	commandUnknown commandKind = iota
+	commandNativePoll
+	commandClassicPoll
+)
+
+// resolveCommandKind maps an application command's name to the kind of poll
+// command it is, or commandUnknown for a name this bot doesn't handle.
+func resolveCommandKind(name string) commandKind {
+	switch name {
+	case "poll":
+		return commandNativePoll
+	case "poll-classic":
+		return commandClassicPoll
+	default:
+		return commandUnknown
+	}
+}
+
 func botHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.Type != discordgo.InteractionApplicationCommand {
 		return
 	}
 	var err error
-	switch i.ApplicationCommandData().Name {
-	case "poll":
+	switch resolveCommandKind(i.ApplicationCommandData().Name) {
+	case commandNativePoll:
 		err = poll.NativePoll(s, i.Interaction)
-	case "poll-classic":
+	case commandClassicPoll:
 		err = poll.ClassicPoll(s, i.Interaction)
 	default:
 		return
@@ -72,7 +93,7 @@ func (b *Bot) Run() error {
 	}
 	defer s.Close()
 
-	manage.Register(s)
+	manage.Register(s, s.State.User.ID)
 
 	log.Println("=====start=====")
 	signalChan := make(chan os.Signal, 1)

--- a/app/bot/bot_test.go
+++ b/app/bot/bot_test.go
@@ -1,0 +1,29 @@
+package bot
+
+import "testing"
+
+func TestNewBot(t *testing.T) {
+	b := NewBot("my-token")
+	if b.token != "my-token" {
+		t.Errorf("token = %q, want %q", b.token, "my-token")
+	}
+}
+
+func TestResolveCommandKind(t *testing.T) {
+	tests := []struct {
+		name string
+		want commandKind
+	}{
+		{"poll", commandNativePoll},
+		{"poll-classic", commandClassicPoll},
+		{"unknown-command", commandUnknown},
+		{"", commandUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveCommandKind(tt.name); got != tt.want {
+				t.Errorf("resolveCommandKind(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/app/manage/manage.go
+++ b/app/manage/manage.go
@@ -8,14 +8,18 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func Register(session *discordgo.Session) error {
-	log.Printf("Registering commands...\n")
-	commands := []*discordgo.ApplicationCommand{
+// commandsToRegister returns the application commands this bot registers.
+func commandsToRegister() []*discordgo.ApplicationCommand {
+	return []*discordgo.ApplicationCommand{
 		poll.GetNativePollCommand(),
 		poll.GetClassicPollCommand(),
 	}
-	for _, command := range commands {
-		_, err := session.ApplicationCommandCreate(session.State.User.ID, "", command)
+}
+
+func Register(session commandSession, appID string) error {
+	log.Printf("Registering commands...\n")
+	for _, command := range commandsToRegister() {
+		_, err := session.ApplicationCommandCreate(appID, "", command)
 		if err != nil {
 			return err
 		}
@@ -24,9 +28,9 @@ func Register(session *discordgo.Session) error {
 	return nil
 }
 
-func Delete(session *discordgo.Session) error {
+func Delete(session commandSession, appID string) error {
 	log.Printf("Deleting registered commands...\n")
-	commands, err := session.ApplicationCommands(session.State.User.ID, "")
+	commands, err := session.ApplicationCommands(appID, "")
 	if err != nil {
 		return err
 	}
@@ -37,7 +41,7 @@ func Delete(session *discordgo.Session) error {
 	}
 
 	for _, command := range commands {
-		err := session.ApplicationCommandDelete(session.State.User.ID, "", command.ID)
+		err := session.ApplicationCommandDelete(appID, "", command.ID)
 		if err != nil {
 			return err
 		}

--- a/app/manage/manage_test.go
+++ b/app/manage/manage_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"7DaysPoll/poll"
+	"7dayspoll/poll"
 
 	"github.com/bwmarrin/discordgo"
 )

--- a/app/manage/manage_test.go
+++ b/app/manage/manage_test.go
@@ -1,0 +1,158 @@
+package manage
+
+import (
+	"errors"
+	"testing"
+
+	"7DaysPoll/poll"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestCommandsToRegister(t *testing.T) {
+	commands := commandsToRegister()
+	if len(commands) != 2 {
+		t.Fatalf("commandsToRegister() returned %d commands, want 2", len(commands))
+	}
+	wantNames := []string{poll.GetNativePollCommand().Name, poll.GetClassicPollCommand().Name}
+	for i, want := range wantNames {
+		if commands[i].Name != want {
+			t.Errorf("commands[%d].Name = %q, want %q", i, commands[i].Name, want)
+		}
+	}
+}
+
+// fakeCommandSession is a hand-written test double for commandSession: it
+// records every call it receives and returns configurable results, so
+// Register/Delete's orchestration can be verified without talking to
+// Discord.
+type fakeCommandSession struct {
+	createCalls []createCall
+	createErr   error
+
+	commands    []*discordgo.ApplicationCommand
+	commandsErr error
+
+	deleteCalls []string
+	deleteErr   error
+}
+
+type createCall struct {
+	appID   string
+	guildID string
+	name    string
+}
+
+func (f *fakeCommandSession) ApplicationCommandCreate(appID, guildID string, cmd *discordgo.ApplicationCommand, _ ...discordgo.RequestOption) (*discordgo.ApplicationCommand, error) {
+	f.createCalls = append(f.createCalls, createCall{appID, guildID, cmd.Name})
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return cmd, nil
+}
+
+func (f *fakeCommandSession) ApplicationCommands(_, _ string, _ ...discordgo.RequestOption) ([]*discordgo.ApplicationCommand, error) {
+	if f.commandsErr != nil {
+		return nil, f.commandsErr
+	}
+	return f.commands, nil
+}
+
+func (f *fakeCommandSession) ApplicationCommandDelete(_, _, cmdID string, _ ...discordgo.RequestOption) error {
+	f.deleteCalls = append(f.deleteCalls, cmdID)
+	return f.deleteErr
+}
+
+func TestRegister(t *testing.T) {
+	t.Run("creates every command to register with the given appID", func(t *testing.T) {
+		fake := &fakeCommandSession{}
+
+		if err := Register(fake, "app-1"); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+
+		want := commandsToRegister()
+		if len(fake.createCalls) != len(want) {
+			t.Fatalf("ApplicationCommandCreate called %d times, want %d", len(fake.createCalls), len(want))
+		}
+		for i, call := range fake.createCalls {
+			if call.appID != "app-1" {
+				t.Errorf("call[%d].appID = %q, want %q", i, call.appID, "app-1")
+			}
+			if call.guildID != "" {
+				t.Errorf("call[%d].guildID = %q, want empty (global command)", i, call.guildID)
+			}
+			if call.name != want[i].Name {
+				t.Errorf("call[%d].name = %q, want %q", i, call.name, want[i].Name)
+			}
+		}
+	})
+
+	t.Run("stops and returns the error as soon as one command fails to create", func(t *testing.T) {
+		wantErr := errors.New("create failed")
+		fake := &fakeCommandSession{createErr: wantErr}
+
+		err := Register(fake, "app-1")
+		if err != wantErr {
+			t.Fatalf("Register() error = %v, want %v", err, wantErr)
+		}
+		if len(fake.createCalls) != 1 {
+			t.Errorf("ApplicationCommandCreate called %d times, want 1 (should stop after the first failure)", len(fake.createCalls))
+		}
+	})
+}
+
+func TestDelete(t *testing.T) {
+	t.Run("deletes every command returned by ApplicationCommands", func(t *testing.T) {
+		fake := &fakeCommandSession{
+			commands: []*discordgo.ApplicationCommand{{ID: "cmd-1"}, {ID: "cmd-2"}},
+		}
+
+		if err := Delete(fake, "app-1"); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		if len(fake.deleteCalls) != 2 || fake.deleteCalls[0] != "cmd-1" || fake.deleteCalls[1] != "cmd-2" {
+			t.Errorf("deleteCalls = %v, want [cmd-1 cmd-2]", fake.deleteCalls)
+		}
+	})
+
+	t.Run("no commands registered: returns nil without deleting anything", func(t *testing.T) {
+		fake := &fakeCommandSession{commands: nil}
+
+		if err := Delete(fake, "app-1"); err != nil {
+			t.Fatalf("Delete() error = %v, want nil", err)
+		}
+		if len(fake.deleteCalls) != 0 {
+			t.Errorf("ApplicationCommandDelete called %d times, want 0", len(fake.deleteCalls))
+		}
+	})
+
+	t.Run("propagates an error from ApplicationCommands without deleting anything", func(t *testing.T) {
+		wantErr := errors.New("list failed")
+		fake := &fakeCommandSession{commandsErr: wantErr}
+
+		err := Delete(fake, "app-1")
+		if err != wantErr {
+			t.Fatalf("Delete() error = %v, want %v", err, wantErr)
+		}
+		if len(fake.deleteCalls) != 0 {
+			t.Errorf("ApplicationCommandDelete called %d times, want 0", len(fake.deleteCalls))
+		}
+	})
+
+	t.Run("stops and returns the error as soon as one command fails to delete", func(t *testing.T) {
+		wantErr := errors.New("delete failed")
+		fake := &fakeCommandSession{
+			commands:  []*discordgo.ApplicationCommand{{ID: "cmd-1"}, {ID: "cmd-2"}},
+			deleteErr: wantErr,
+		}
+
+		err := Delete(fake, "app-1")
+		if err != wantErr {
+			t.Fatalf("Delete() error = %v, want %v", err, wantErr)
+		}
+		if len(fake.deleteCalls) != 1 {
+			t.Errorf("ApplicationCommandDelete called %d times, want 1 (should stop after the first failure)", len(fake.deleteCalls))
+		}
+	})
+}

--- a/app/manage/session.go
+++ b/app/manage/session.go
@@ -1,0 +1,13 @@
+package manage
+
+import "github.com/bwmarrin/discordgo"
+
+// commandSession is the subset of *discordgo.Session's API that Register and
+// Delete depend on. Depending on this narrow interface instead of the
+// concrete session lets tests substitute a fake implementation instead of
+// talking to Discord.
+type commandSession interface {
+	ApplicationCommandCreate(appID, guildID string, cmd *discordgo.ApplicationCommand, options ...discordgo.RequestOption) (*discordgo.ApplicationCommand, error)
+	ApplicationCommands(appID, guildID string, options ...discordgo.RequestOption) ([]*discordgo.ApplicationCommand, error)
+	ApplicationCommandDelete(appID, guildID, cmdID string, options ...discordgo.RequestOption) error
+}

--- a/app/poll/context_test.go
+++ b/app/poll/context_test.go
@@ -1,0 +1,44 @@
+package poll
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewAggregationContext(t *testing.T) {
+	t.Run("second call for the same message cancels the first context", func(t *testing.T) {
+		first := NewAggregationContext("channel-1", "message-1")
+		second := NewAggregationContext("channel-1", "message-1")
+
+		select {
+		case <-first.Done():
+		default:
+			t.Fatal("expected the first context to be canceled once a second one is created for the same message")
+		}
+		if err := first.Err(); err != context.Canceled {
+			t.Errorf("first.Err() = %v, want %v", err, context.Canceled)
+		}
+
+		select {
+		case <-second.Done():
+			t.Fatal("expected the second (latest) context to still be active")
+		default:
+		}
+	})
+
+	t.Run("different messages get independent contexts", func(t *testing.T) {
+		a := NewAggregationContext("channel-2", "message-a")
+		b := NewAggregationContext("channel-2", "message-b")
+
+		select {
+		case <-a.Done():
+			t.Fatal("expected context for message-a to remain active")
+		default:
+		}
+		select {
+		case <-b.Done():
+			t.Fatal("expected context for message-b to remain active")
+		default:
+		}
+	})
+}

--- a/app/poll/poll-classic.go
+++ b/app/poll/poll-classic.go
@@ -43,7 +43,8 @@ func GetClassicPollCommand() *discordgo.ApplicationCommand {
 
 func ClassicPoll(session *discordgo.Session, interaction *discordgo.Interaction) error {
 	i18n := GetI18n(interaction.Locale)
-	opts, err := parsePollOptions(interaction, i18n, time.Now())
+	now := time.Now()
+	opts, err := parsePollOptions(interaction, i18n, now)
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func ClassicPoll(session *discordgo.Session, interaction *discordgo.Interaction)
 
 	messageURL := buildMessageURL(interaction.GuildID, interaction.ChannelID, message.ID)
 
-	eventStart := resolveEventStartTime(start, numDays, time.Now())
+	eventStart := resolveEventStartTime(start, numDays, now)
 	event, err := createScheduledEvent(session, interaction.GuildID, i18n, start, numDays, title, messageURL, eventStart)
 	if err != nil {
 		log.Println("Failed to create guild scheduled event:", err)

--- a/app/poll/poll-classic.go
+++ b/app/poll/poll-classic.go
@@ -43,7 +43,7 @@ func GetClassicPollCommand() *discordgo.ApplicationCommand {
 
 func ClassicPoll(session *discordgo.Session, interaction *discordgo.Interaction) error {
 	i18n := GetI18n(interaction.Locale)
-	opts, err := parsePollOptions(interaction, i18n)
+	opts, err := parsePollOptions(interaction, i18n, time.Now())
 	if err != nil {
 		return err
 	}

--- a/app/poll/poll-classic.go
+++ b/app/poll/poll-classic.go
@@ -103,7 +103,13 @@ func ClassicPoll(session *discordgo.Session, interaction *discordgo.Interaction)
 
 	messageURL := buildMessageURL(interaction.GuildID, interaction.ChannelID, message.ID)
 
-	eventStart := resolveEventStartTime(start, numDays, now)
+	// Re-read the clock here rather than reusing the `now` captured before
+	// the Discord I/O above (InteractionRespond/InteractionResponse and up
+	// to 8 sequential MessageReactionAdd calls): if enough real time has
+	// elapsed during that I/O to cross the final candidate day's midnight,
+	// a stale `now` would miss it, causing resolveEventStartTime to return
+	// an already-past ScheduledStartTime that Discord silently rejects.
+	eventStart := resolveEventStartTime(start, numDays, time.Now())
 	event, err := createScheduledEvent(session, interaction.GuildID, i18n, start, numDays, title, messageURL, eventStart)
 	if err != nil {
 		log.Println("Failed to create guild scheduled event:", err)

--- a/app/poll/poll-native.go
+++ b/app/poll/poll-native.go
@@ -58,7 +58,8 @@ func GetNativePollCommand() *discordgo.ApplicationCommand {
 
 func NativePoll(session *discordgo.Session, interaction *discordgo.Interaction) error {
 	i18n := GetI18n(interaction.Locale)
-	opts, err := parsePollOptions(interaction, i18n)
+	now := time.Now()
+	opts, err := parsePollOptions(interaction, i18n, now)
 	if err != nil {
 		return err
 	}
@@ -87,7 +88,6 @@ func NativePoll(session *discordgo.Session, interaction *discordgo.Interaction) 
 	// when an event will actually be created, i.e. not in a DM). eventStart is
 	// reused below when actually creating the event, so the two can never
 	// disagree on when the event starts.
-	now := time.Now()
 	var eventStart time.Time
 	if interaction.GuildID != "" {
 		eventStart = resolveEventStartTime(opts.Start, opts.NumDays, now)

--- a/app/poll/poll-native.go
+++ b/app/poll/poll-native.go
@@ -56,15 +56,12 @@ func GetNativePollCommand() *discordgo.ApplicationCommand {
 	}
 }
 
-func NativePoll(session *discordgo.Session, interaction *discordgo.Interaction) error {
-	i18n := GetI18n(interaction.Locale)
-	now := time.Now()
-	opts, err := parsePollOptions(interaction, i18n, now)
-	if err != nil {
-		return err
-	}
+// resolveDurationHours returns the poll's duration in hours, from the
+// "duration" option (default defaultDurationDays, clamped to
+// [minDurationDays, maxDurationDays] days).
+func resolveDurationHours(optMap map[string]*discordgo.ApplicationCommandInteractionDataOption) int {
 	durationDays := defaultDurationDays
-	if d, ok := opts.OptMap["duration"]; ok {
+	if d, ok := optMap["duration"]; ok {
 		durationDays = int(d.IntValue())
 		if durationDays < minDurationDays {
 			durationDays = minDurationDays
@@ -72,7 +69,12 @@ func NativePoll(session *discordgo.Session, interaction *discordgo.Interaction) 
 			durationDays = maxDurationDays
 		}
 	}
-	choices := getChoices(i18n, opts.Start, opts.NumDays)
+	return durationDays * 24
+}
+
+// buildPollAnswers converts poll date choices into Discord native poll
+// answers.
+func buildPollAnswers(choices []Choice) []discordgo.PollAnswer {
 	answers := make([]discordgo.PollAnswer, 0, len(choices))
 	for _, choice := range choices {
 		answers = append(answers, discordgo.PollAnswer{
@@ -82,7 +84,35 @@ func NativePoll(session *discordgo.Session, interaction *discordgo.Interaction) 
 			},
 		})
 	}
-	durationHours := durationDays * 24
+	return answers
+}
+
+// buildNativePollResponse builds the interaction response that creates a
+// Discord native poll message.
+func buildNativePollResponse(title string, answers []discordgo.PollAnswer, durationHours int) *discordgo.InteractionResponse {
+	return &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Poll: &discordgo.Poll{
+				Question:         discordgo.PollMedia{Text: truncateRunes(title, pollQuestionMaxLength)},
+				Answers:          answers,
+				AllowMultiselect: true,
+				Duration:         durationHours,
+			},
+		},
+	}
+}
+
+func NativePoll(session pollSession, interaction *discordgo.Interaction) error {
+	i18n := GetI18n(interaction.Locale)
+	now := time.Now()
+	opts, err := parsePollOptions(interaction, i18n, now)
+	if err != nil {
+		return err
+	}
+	choices := getChoices(i18n, opts.Start, opts.NumDays)
+	answers := buildPollAnswers(choices)
+	durationHours := resolveDurationHours(opts.OptMap)
 	// A poll shouldn't outlive the scheduled event linked to it, so clamp the
 	// duration to the time remaining before the event's start (only relevant
 	// when an event will actually be created, i.e. not in a DM). eventStart is
@@ -93,18 +123,8 @@ func NativePoll(session *discordgo.Session, interaction *discordgo.Interaction) 
 		eventStart = resolveEventStartTime(opts.Start, opts.NumDays, now)
 		durationHours = clampPollDurationToEvent(durationHours, eventStart, now)
 	}
-	body := discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Poll: &discordgo.Poll{
-				Question:         discordgo.PollMedia{Text: truncateRunes(opts.Title, pollQuestionMaxLength)},
-				Answers:          answers,
-				AllowMultiselect: true,
-				Duration:         durationHours,
-			},
-		},
-	}
-	err = session.InteractionRespond(interaction, &body)
+	body := buildNativePollResponse(opts.Title, answers, durationHours)
+	err = session.InteractionRespond(interaction, body)
 	if err != nil {
 		log.Println(err)
 		return err

--- a/app/poll/poll-native_test.go
+++ b/app/poll/poll-native_test.go
@@ -1,0 +1,67 @@
+package poll
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestGetNativePollCommand(t *testing.T) {
+	cmd := GetNativePollCommand()
+
+	if cmd.Name != "poll" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "poll")
+	}
+	if cmd.Type != discordgo.ChatApplicationCommand {
+		t.Errorf("Type = %v, want %v", cmd.Type, discordgo.ChatApplicationCommand)
+	}
+
+	optionsByName := map[string]*discordgo.ApplicationCommandOption{}
+	for _, opt := range cmd.Options {
+		optionsByName[opt.Name] = opt
+	}
+
+	titleOpt, ok := optionsByName["title"]
+	if !ok {
+		t.Fatal("expected a \"title\" option")
+	}
+	if titleOpt.Type != discordgo.ApplicationCommandOptionString {
+		t.Errorf("title option Type = %v, want string", titleOpt.Type)
+	}
+	if titleOpt.MaxLength != pollQuestionMaxLength {
+		t.Errorf("title option MaxLength = %d, want %d (Discord's poll question limit)", titleOpt.MaxLength, pollQuestionMaxLength)
+	}
+
+	daysOpt, ok := optionsByName["days"]
+	if !ok {
+		t.Fatal("expected a \"days\" option")
+	}
+	if daysOpt.MinValue == nil || *daysOpt.MinValue != 2 {
+		t.Errorf("days option MinValue = %v, want 2", daysOpt.MinValue)
+	}
+	if daysOpt.MaxValue != 7 {
+		t.Errorf("days option MaxValue = %v, want 7", daysOpt.MaxValue)
+	}
+
+	durationOpt, ok := optionsByName["duration"]
+	if !ok {
+		t.Fatal("expected a \"duration\" option")
+	}
+	if durationOpt.MinValue == nil || *durationOpt.MinValue != minDurationDays {
+		t.Errorf("duration option MinValue = %v, want %d", durationOpt.MinValue, minDurationDays)
+	}
+	if durationOpt.MaxValue != maxDurationDays {
+		t.Errorf("duration option MaxValue = %v, want %d", durationOpt.MaxValue, maxDurationDays)
+	}
+
+	startDateOpt, ok := optionsByName["start-date"]
+	if !ok {
+		t.Fatal("expected a \"start-date\" option")
+	}
+	if startDateOpt.MinLength == nil || *startDateOpt.MinLength != 5 {
+		t.Errorf("start-date option MinLength = %v, want 5", startDateOpt.MinLength)
+	}
+	if startDateOpt.MaxLength != 5 {
+		t.Errorf("start-date option MaxLength = %d, want 5", startDateOpt.MaxLength)
+	}
+}

--- a/app/poll/poll-native_test.go
+++ b/app/poll/poll-native_test.go
@@ -1,6 +1,7 @@
 package poll
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
@@ -64,4 +65,261 @@ func TestGetNativePollCommand(t *testing.T) {
 	if startDateOpt.MaxLength != 5 {
 		t.Errorf("start-date option MaxLength = %d, want 5", startDateOpt.MaxLength)
 	}
+}
+
+func TestResolveDurationHours(t *testing.T) {
+	tests := []struct {
+		name string
+		opt  *discordgo.ApplicationCommandInteractionDataOption
+		want int
+	}{
+		{"not given defaults to defaultDurationDays", nil, defaultDurationDays * 24},
+		{"below minimum is clamped up to minDurationDays", intOpt("duration", 0), minDurationDays * 24},
+		{"above maximum is clamped down to maxDurationDays", intOpt("duration", 100), maxDurationDays * 24},
+		{"within range is kept as-is", intOpt("duration", 5), 5 * 24},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			optMap := map[string]*discordgo.ApplicationCommandInteractionDataOption{}
+			if tt.opt != nil {
+				optMap["duration"] = tt.opt
+			}
+			if got := resolveDurationHours(optMap); got != tt.want {
+				t.Errorf("resolveDurationHours() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPollAnswers(t *testing.T) {
+	choices := []Choice{
+		{Emoji: "1⃣", Name: "08/21 (Fri)"},
+		{Emoji: "❌", Name: "Absence"},
+	}
+	answers := buildPollAnswers(choices)
+	if len(answers) != len(choices) {
+		t.Fatalf("buildPollAnswers() returned %d answers, want %d", len(answers), len(choices))
+	}
+	for i, choice := range choices {
+		if answers[i].Media.Text != choice.Name {
+			t.Errorf("answers[%d].Media.Text = %q, want %q", i, answers[i].Media.Text, choice.Name)
+		}
+		if answers[i].Media.Emoji.Name != choice.Emoji {
+			t.Errorf("answers[%d].Media.Emoji.Name = %q, want %q", i, answers[i].Media.Emoji.Name, choice.Emoji)
+		}
+	}
+}
+
+func TestBuildNativePollResponse(t *testing.T) {
+	answers := []discordgo.PollAnswer{{Media: &discordgo.PollMedia{Text: "08/21 (Fri)"}}}
+	longTitle := ""
+	for i := 0; i < pollQuestionMaxLength+10; i++ {
+		longTitle += "a"
+	}
+
+	resp := buildNativePollResponse(longTitle, answers, 72)
+
+	if resp.Type != discordgo.InteractionResponseChannelMessageWithSource {
+		t.Errorf("Type = %v, want %v", resp.Type, discordgo.InteractionResponseChannelMessageWithSource)
+	}
+	poll := resp.Data.Poll
+	if poll == nil {
+		t.Fatal("Data.Poll is nil")
+	}
+	if len([]rune(poll.Question.Text)) != pollQuestionMaxLength {
+		t.Errorf("Question.Text length = %d, want %d (truncated to Discord's limit)", len([]rune(poll.Question.Text)), pollQuestionMaxLength)
+	}
+	if !poll.AllowMultiselect {
+		t.Error("AllowMultiselect = false, want true")
+	}
+	if poll.Duration != 72 {
+		t.Errorf("Duration = %d, want 72", poll.Duration)
+	}
+	if len(poll.Answers) != 1 || poll.Answers[0].Media.Text != "08/21 (Fri)" {
+		t.Errorf("Answers = %+v, want the given answers to be passed through unchanged", poll.Answers)
+	}
+}
+
+// fakePollSession is a hand-written test double for pollSession: it records
+// every call it receives and returns configurable results, so NativePoll's
+// orchestration (which methods are called, in what order, with what data)
+// can be verified without talking to Discord.
+type fakePollSession struct {
+	interactionRespondCalls []*discordgo.InteractionResponse
+	interactionRespondErr   error
+
+	interactionResponseCalls   int
+	interactionResponseMessage *discordgo.Message
+	interactionResponseErr     error
+
+	guildScheduledEventCreateCalls []guildScheduledEventCreateCall
+	guildScheduledEventCreateEvent *discordgo.GuildScheduledEvent
+	guildScheduledEventCreateErr   error
+
+	followupMessageCreateCalls []*discordgo.WebhookParams
+	followupMessageCreateErr   error
+}
+
+type guildScheduledEventCreateCall struct {
+	guildID string
+	params  *discordgo.GuildScheduledEventParams
+}
+
+func (f *fakePollSession) InteractionRespond(_ *discordgo.Interaction, resp *discordgo.InteractionResponse, _ ...discordgo.RequestOption) error {
+	f.interactionRespondCalls = append(f.interactionRespondCalls, resp)
+	return f.interactionRespondErr
+}
+
+func (f *fakePollSession) InteractionResponse(_ *discordgo.Interaction, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
+	f.interactionResponseCalls++
+	if f.interactionResponseErr != nil {
+		return nil, f.interactionResponseErr
+	}
+	if f.interactionResponseMessage != nil {
+		return f.interactionResponseMessage, nil
+	}
+	return &discordgo.Message{ID: "message-1"}, nil
+}
+
+func (f *fakePollSession) FollowupMessageCreate(_ *discordgo.Interaction, _ bool, data *discordgo.WebhookParams, _ ...discordgo.RequestOption) (*discordgo.Message, error) {
+	f.followupMessageCreateCalls = append(f.followupMessageCreateCalls, data)
+	return nil, f.followupMessageCreateErr
+}
+
+func (f *fakePollSession) GuildScheduledEventCreate(guildID string, event *discordgo.GuildScheduledEventParams, _ ...discordgo.RequestOption) (*discordgo.GuildScheduledEvent, error) {
+	f.guildScheduledEventCreateCalls = append(f.guildScheduledEventCreateCalls, guildScheduledEventCreateCall{guildID, event})
+	if f.guildScheduledEventCreateErr != nil {
+		return nil, f.guildScheduledEventCreateErr
+	}
+	if f.guildScheduledEventCreateEvent != nil {
+		return f.guildScheduledEventCreateEvent, nil
+	}
+	return &discordgo.GuildScheduledEvent{ID: "event-1"}, nil
+}
+
+func newGuildInteraction() *discordgo.Interaction {
+	interaction := newCommandInteraction(discordgo.EnglishUS, nil)
+	interaction.GuildID = "guild-1"
+	interaction.ChannelID = "channel-1"
+	return interaction
+}
+
+func TestNativePoll(t *testing.T) {
+	t.Run("in a DM, only responds with the poll and does nothing guild-related", func(t *testing.T) {
+		fake := &fakePollSession{}
+		interaction := newCommandInteraction(discordgo.EnglishUS, nil) // GuildID is "" by default: a DM
+
+		if err := NativePoll(fake, interaction); err != nil {
+			t.Fatalf("NativePoll() error = %v", err)
+		}
+
+		if len(fake.interactionRespondCalls) != 1 {
+			t.Fatalf("InteractionRespond called %d times, want 1", len(fake.interactionRespondCalls))
+		}
+		poll := fake.interactionRespondCalls[0].Data.Poll
+		if len(poll.Answers) != 8 {
+			t.Errorf("Answers count = %d, want 8 (7 default days + absence)", len(poll.Answers))
+		}
+		if poll.Duration != defaultDurationDays*24 {
+			t.Errorf("Duration = %d, want %d", poll.Duration, defaultDurationDays*24)
+		}
+		if fake.interactionResponseCalls != 0 {
+			t.Error("InteractionResponse was called, want it not to be (no scheduled event in a DM)")
+		}
+		if len(fake.guildScheduledEventCreateCalls) != 0 {
+			t.Error("GuildScheduledEventCreate was called, want it not to be (no scheduled event in a DM)")
+		}
+		if len(fake.followupMessageCreateCalls) != 0 {
+			t.Error("FollowupMessageCreate was called, want it not to be (no scheduled event in a DM)")
+		}
+	})
+
+	t.Run("in a guild, creates the poll, the scheduled event, and the follow-up link", func(t *testing.T) {
+		fake := &fakePollSession{
+			guildScheduledEventCreateEvent: &discordgo.GuildScheduledEvent{ID: "event-42"},
+		}
+		interaction := newGuildInteraction()
+
+		if err := NativePoll(fake, interaction); err != nil {
+			t.Fatalf("NativePoll() error = %v", err)
+		}
+
+		if len(fake.interactionRespondCalls) != 1 {
+			t.Fatalf("InteractionRespond called %d times, want 1", len(fake.interactionRespondCalls))
+		}
+		if fake.interactionResponseCalls != 1 {
+			t.Fatalf("InteractionResponse called %d times, want 1", fake.interactionResponseCalls)
+		}
+		if len(fake.guildScheduledEventCreateCalls) != 1 {
+			t.Fatalf("GuildScheduledEventCreate called %d times, want 1", len(fake.guildScheduledEventCreateCalls))
+		}
+		call := fake.guildScheduledEventCreateCalls[0]
+		if call.guildID != "guild-1" {
+			t.Errorf("GuildScheduledEventCreate guildID = %q, want %q", call.guildID, "guild-1")
+		}
+		wantMessageURL := buildMessageURL("guild-1", "channel-1", "message-1")
+		if call.params.EntityMetadata.Location != wantMessageURL {
+			t.Errorf("EntityMetadata.Location = %q, want %q", call.params.EntityMetadata.Location, wantMessageURL)
+		}
+
+		if len(fake.followupMessageCreateCalls) != 1 {
+			t.Fatalf("FollowupMessageCreate called %d times, want 1", len(fake.followupMessageCreateCalls))
+		}
+		wantEventURL := buildEventURL("guild-1", "event-42")
+		if fake.followupMessageCreateCalls[0].Content != wantEventURL {
+			t.Errorf("FollowupMessageCreate Content = %q, want %q", fake.followupMessageCreateCalls[0].Content, wantEventURL)
+		}
+	})
+
+	t.Run("InteractionRespond error is returned and stops further calls", func(t *testing.T) {
+		wantErr := errors.New("interaction respond failed")
+		fake := &fakePollSession{interactionRespondErr: wantErr}
+		interaction := newGuildInteraction()
+
+		err := NativePoll(fake, interaction)
+		if err != wantErr {
+			t.Fatalf("NativePoll() error = %v, want %v", err, wantErr)
+		}
+		if fake.interactionResponseCalls != 0 {
+			t.Error("InteractionResponse was called, want it not to be")
+		}
+		if len(fake.guildScheduledEventCreateCalls) != 0 {
+			t.Error("GuildScheduledEventCreate was called, want it not to be")
+		}
+	})
+
+	t.Run("InteractionResponse error is returned and stops further calls", func(t *testing.T) {
+		wantErr := errors.New("interaction response failed")
+		fake := &fakePollSession{interactionResponseErr: wantErr}
+		interaction := newGuildInteraction()
+
+		err := NativePoll(fake, interaction)
+		if err != wantErr {
+			t.Fatalf("NativePoll() error = %v, want %v", err, wantErr)
+		}
+		if len(fake.guildScheduledEventCreateCalls) != 0 {
+			t.Error("GuildScheduledEventCreate was called, want it not to be")
+		}
+	})
+
+	t.Run("GuildScheduledEventCreate error is only logged: NativePoll still returns nil and skips the follow-up", func(t *testing.T) {
+		fake := &fakePollSession{guildScheduledEventCreateErr: errors.New("event create failed")}
+		interaction := newGuildInteraction()
+
+		if err := NativePoll(fake, interaction); err != nil {
+			t.Fatalf("NativePoll() error = %v, want nil", err)
+		}
+		if len(fake.followupMessageCreateCalls) != 0 {
+			t.Error("FollowupMessageCreate was called, want it not to be")
+		}
+	})
+
+	t.Run("FollowupMessageCreate error is only logged: NativePoll still returns nil", func(t *testing.T) {
+		fake := &fakePollSession{followupMessageCreateErr: errors.New("follow-up failed")}
+		interaction := newGuildInteraction()
+
+		if err := NativePoll(fake, interaction); err != nil {
+			t.Fatalf("NativePoll() error = %v, want nil", err)
+		}
+	})
 }

--- a/app/poll/poll.go
+++ b/app/poll/poll.go
@@ -93,23 +93,34 @@ func parsePollOptions(interaction *discordgo.Interaction, i18n I18n) (*pollOptio
 	}
 	// judgement start date
 	now := time.Now().In(timezone)
-	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, timezone)
-	if date, ok := optMap["start-date"]; ok {
-		yearDate := fmt.Sprintf("%d/%s", now.Year(), date.StringValue())
-		yd, err := time.ParseInLocation("2006/01/02", yearDate, timezone)
-		if err == nil {
-			if start.After(yd) {
-				yd = yd.AddDate(1, 0, 0)
-			}
-			start = yd
-		}
-	}
+	start := resolveStartDate(now, timezone, optMap["start-date"])
 	return &pollOptions{
 		Title:   title,
 		Start:   start,
 		NumDays: numDays,
 		OptMap:  optMap,
 	}, nil
+}
+
+// resolveStartDate returns the poll's start date: today at local midnight in
+// timezone, or, when dateOpt is a valid "MM/DD" start-date option, that
+// day resolved to this year (or next year, if that day-of-year has already
+// passed today). dateOpt may be nil, and an unparseable value falls back to
+// today at local midnight.
+func resolveStartDate(now time.Time, timezone *time.Location, dateOpt *discordgo.ApplicationCommandInteractionDataOption) time.Time {
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, timezone)
+	if dateOpt == nil {
+		return start
+	}
+	yearDate := fmt.Sprintf("%d/%s", now.Year(), dateOpt.StringValue())
+	yd, err := time.ParseInLocation("2006/01/02", yearDate, timezone)
+	if err != nil {
+		return start
+	}
+	if start.After(yd) {
+		yd = yd.AddDate(1, 0, 0)
+	}
+	return yd
 }
 
 func buildMessageURL(guildID, channelID, messageID string) string {

--- a/app/poll/poll.go
+++ b/app/poll/poll.go
@@ -61,7 +61,7 @@ type pollOptions struct {
 	OptMap  map[string]*discordgo.ApplicationCommandInteractionDataOption
 }
 
-func parsePollOptions(interaction *discordgo.Interaction, i18n I18n) (*pollOptions, error) {
+func parsePollOptions(interaction *discordgo.Interaction, i18n I18n, now time.Time) (*pollOptions, error) {
 	// get timezone
 	timezone, err := GetTimeZone(interaction.Locale)
 	if err != nil {
@@ -92,8 +92,7 @@ func parsePollOptions(interaction *discordgo.Interaction, i18n I18n) (*pollOptio
 		}
 	}
 	// judgement start date
-	now := time.Now().In(timezone)
-	start := resolveStartDate(now, timezone, optMap["start-date"])
+	start := resolveStartDate(now.In(timezone), timezone, optMap["start-date"])
 	return &pollOptions{
 		Title:   title,
 		Start:   start,

--- a/app/poll/poll.go
+++ b/app/poll/poll.go
@@ -173,13 +173,17 @@ func clampPollDurationToEvent(durationHours int, eventStart, now time.Time) int 
 	return durationHours
 }
 
-func createScheduledEvent(session *discordgo.Session, guildID string, i18n I18n, start time.Time, numDays int, title string, messageURL string, eventStart time.Time) (*discordgo.GuildScheduledEvent, error) {
+// buildGuildScheduledEventParams builds the parameters for the guild
+// scheduled event linked to a poll: it runs from eventStart through the end
+// of the final candidate day, and links back to the poll message via
+// messageURL.
+func buildGuildScheduledEventParams(i18n I18n, start time.Time, numDays int, title string, messageURL string, eventStart time.Time) *discordgo.GuildScheduledEventParams {
 	eventTitle := truncateRunes(i18n.VotingPeriod+title, discordEventNameMaxLength)
 
 	finalCandidateDayMidnight := eventStartTime(start, numDays)
 	endTime := time.Date(finalCandidateDayMidnight.Year(), finalCandidateDayMidnight.Month(), finalCandidateDayMidnight.Day(), 23, 59, 59, 0, start.Location())
 
-	eventParams := &discordgo.GuildScheduledEventParams{
+	return &discordgo.GuildScheduledEventParams{
 		Name:               eventTitle,
 		Description:        fmt.Sprintf("%s: %s", i18n.PollMessage, messageURL),
 		ScheduledStartTime: &eventStart,
@@ -190,6 +194,9 @@ func createScheduledEvent(session *discordgo.Session, guildID string, i18n I18n,
 			Location: messageURL,
 		},
 	}
+}
 
+func createScheduledEvent(session pollSession, guildID string, i18n I18n, start time.Time, numDays int, title string, messageURL string, eventStart time.Time) (*discordgo.GuildScheduledEvent, error) {
+	eventParams := buildGuildScheduledEventParams(i18n, start, numDays, title, messageURL, eventStart)
 	return session.GuildScheduledEventCreate(guildID, eventParams)
 }

--- a/app/poll/poll_test.go
+++ b/app/poll/poll_test.go
@@ -248,11 +248,12 @@ func TestParsePollOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("unrecognized error from GetTimeZone is returned", func(t *testing.T) {
+	t.Run("an unmapped locale falls back to time.Local instead of erroring", func(t *testing.T) {
 		// GetTimeZone only special-cases discordgo.Japanese and otherwise
-		// falls back to time.Local without error, so parsePollOptions
-		// currently has no locale that reaches its error branch; this test
-		// documents that GetTimeZone never errors for the locales in use.
+		// falls back to time.Local without error, so no discordgo.Locale
+		// value currently reaches parsePollOptions' `if err != nil` branch;
+		// this test only documents that fact, it does not exercise error
+		// propagation.
 		interaction := newCommandInteraction(discordgo.German, nil)
 		_, err := parsePollOptions(interaction, i18n, fixedNow)
 		if err != nil {

--- a/app/poll/poll_test.go
+++ b/app/poll/poll_test.go
@@ -166,10 +166,14 @@ func intOpt(name string, value int) *discordgo.ApplicationCommandInteractionData
 
 func TestParsePollOptions(t *testing.T) {
 	i18n := I18n{DefaultTitle: "Poll"}
+	// A fixed reference "now", used everywhere below instead of the real
+	// wall clock, so results are fully deterministic regardless of when or
+	// how fast the test runs.
+	fixedNow := time.Date(2026, time.June, 15, 9, 0, 0, 0, time.UTC)
 
 	t.Run("title falls back to the default when not given", func(t *testing.T) {
 		interaction := newCommandInteraction(discordgo.EnglishUS, nil)
-		opts, err := parsePollOptions(interaction, i18n)
+		opts, err := parsePollOptions(interaction, i18n, fixedNow)
 		if err != nil {
 			t.Fatalf("parsePollOptions() error = %v", err)
 		}
@@ -182,7 +186,7 @@ func TestParsePollOptions(t *testing.T) {
 		interaction := newCommandInteraction(discordgo.EnglishUS, []*discordgo.ApplicationCommandInteractionDataOption{
 			stringOpt("title", "My Poll"),
 		})
-		opts, err := parsePollOptions(interaction, i18n)
+		opts, err := parsePollOptions(interaction, i18n, fixedNow)
 		if err != nil {
 			t.Fatalf("parsePollOptions() error = %v", err)
 		}
@@ -193,7 +197,7 @@ func TestParsePollOptions(t *testing.T) {
 
 	t.Run("days defaults to 7 when not given", func(t *testing.T) {
 		interaction := newCommandInteraction(discordgo.EnglishUS, nil)
-		opts, err := parsePollOptions(interaction, i18n)
+		opts, err := parsePollOptions(interaction, i18n, fixedNow)
 		if err != nil {
 			t.Fatalf("parsePollOptions() error = %v", err)
 		}
@@ -216,7 +220,7 @@ func TestParsePollOptions(t *testing.T) {
 			interaction := newCommandInteraction(discordgo.EnglishUS, []*discordgo.ApplicationCommandInteractionDataOption{
 				intOpt("days", tt.given),
 			})
-			opts, err := parsePollOptions(interaction, i18n)
+			opts, err := parsePollOptions(interaction, i18n, fixedNow)
 			if err != nil {
 				t.Fatalf("parsePollOptions() error = %v", err)
 			}
@@ -231,11 +235,11 @@ func TestParsePollOptions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetTimeZone() error = %v", err)
 		}
-		now := time.Now().In(timezone)
-		wantStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, timezone)
+		localNow := fixedNow.In(timezone)
+		wantStart := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, timezone)
 
 		interaction := newCommandInteraction(discordgo.EnglishUS, nil)
-		opts, err := parsePollOptions(interaction, i18n)
+		opts, err := parsePollOptions(interaction, i18n, fixedNow)
 		if err != nil {
 			t.Fatalf("parsePollOptions() error = %v", err)
 		}
@@ -250,7 +254,7 @@ func TestParsePollOptions(t *testing.T) {
 		// currently has no locale that reaches its error branch; this test
 		// documents that GetTimeZone never errors for the locales in use.
 		interaction := newCommandInteraction(discordgo.German, nil)
-		_, err := parsePollOptions(interaction, i18n)
+		_, err := parsePollOptions(interaction, i18n, fixedNow)
 		if err != nil {
 			t.Fatalf("parsePollOptions() error = %v, want nil", err)
 		}

--- a/app/poll/poll_test.go
+++ b/app/poll/poll_test.go
@@ -1,0 +1,371 @@
+package poll
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestGetDays(t *testing.T) {
+	start := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		numDays int
+		want    []time.Time
+	}{
+		{
+			name:    "single day returns just the start day",
+			numDays: 1,
+			want:    []time.Time{start},
+		},
+		{
+			name:    "multiple days returns consecutive dates starting from start",
+			numDays: 3,
+			want: []time.Time{
+				start,
+				start.AddDate(0, 0, 1),
+				start.AddDate(0, 0, 2),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDays(start, tt.numDays)
+			if len(got) != len(tt.want) {
+				t.Fatalf("getDays() returned %d days, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if !got[i].Equal(tt.want[i]) {
+					t.Errorf("getDays()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetEmojis(t *testing.T) {
+	got := getEmojis()
+	// One numbered emoji per day of the week (1-7) plus the absence "❌"
+	// option, since a poll offers at most 7 candidate days.
+	if len(got) != 8 {
+		t.Fatalf("getEmojis() returned %d emojis, want 8", len(got))
+	}
+	if got[7] != "❌" {
+		t.Errorf("getEmojis()[7] = %q, want the absence emoji %q", got[7], "❌")
+	}
+}
+
+func TestGetChoices(t *testing.T) {
+	i18n := I18n{
+		Weekdays: []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"},
+		Absence:  "Absence",
+	}
+	// 2026-08-21 is a Friday.
+	start := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+
+	choices := getChoices(i18n, start, 3)
+
+	if len(choices) != 4 {
+		t.Fatalf("getChoices() returned %d choices, want 4 (3 days + absence)", len(choices))
+	}
+	want := []Choice{
+		{Emoji: "1⃣", Name: "08/21 (Fri)"},
+		{Emoji: "2⃣", Name: "08/22 (Sat)"},
+		{Emoji: "3⃣", Name: "08/23 (Sun)"},
+		{Emoji: "❌", Name: "Absence"},
+	}
+	for i, w := range want {
+		if choices[i] != w {
+			t.Errorf("getChoices()[%d] = %+v, want %+v", i, choices[i], w)
+		}
+	}
+}
+
+func TestResolveStartDate(t *testing.T) {
+	// Fixed reference "now" so the year-rollover branch is exercised
+	// deterministically instead of depending on the real wall clock.
+	now := time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC)
+
+	stringOption := func(v string) *discordgo.ApplicationCommandInteractionDataOption {
+		return &discordgo.ApplicationCommandInteractionDataOption{
+			Type:  discordgo.ApplicationCommandOptionString,
+			Value: v,
+		}
+	}
+
+	tests := []struct {
+		name string
+		opt  *discordgo.ApplicationCommandInteractionDataOption
+		want time.Time
+	}{
+		{
+			name: "no option given returns today at midnight",
+			opt:  nil,
+			want: time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "date later this year than today is kept in the current year",
+			opt:  stringOption("12/25"),
+			want: time.Date(2026, time.December, 25, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "date already passed this year rolls over to next year",
+			opt:  stringOption("01/10"),
+			want: time.Date(2027, time.January, 10, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "today's own date is kept in the current year, not rolled over",
+			opt:  stringOption("06/15"),
+			want: time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "unparseable date falls back to today at midnight",
+			opt:  stringOption("not-a-date"),
+			want: time.Date(2026, time.June, 15, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveStartDate(now, time.UTC, tt.opt)
+			if !got.Equal(tt.want) {
+				t.Errorf("resolveStartDate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newCommandInteraction(locale discordgo.Locale, options []*discordgo.ApplicationCommandInteractionDataOption) *discordgo.Interaction {
+	return &discordgo.Interaction{
+		Type:   discordgo.InteractionApplicationCommand,
+		Locale: locale,
+		Data: discordgo.ApplicationCommandInteractionData{
+			Options: options,
+		},
+	}
+}
+
+func stringOpt(name, value string) *discordgo.ApplicationCommandInteractionDataOption {
+	return &discordgo.ApplicationCommandInteractionDataOption{
+		Name:  name,
+		Type:  discordgo.ApplicationCommandOptionString,
+		Value: value,
+	}
+}
+
+func intOpt(name string, value int) *discordgo.ApplicationCommandInteractionDataOption {
+	return &discordgo.ApplicationCommandInteractionDataOption{
+		Name: name,
+		Type: discordgo.ApplicationCommandOptionInteger,
+		// Discord interaction payloads are JSON, so numeric option values
+		// arrive as float64; IntValue() relies on that representation.
+		Value: float64(value),
+	}
+}
+
+func TestParsePollOptions(t *testing.T) {
+	i18n := I18n{DefaultTitle: "Poll"}
+
+	t.Run("title falls back to the default when not given", func(t *testing.T) {
+		interaction := newCommandInteraction(discordgo.EnglishUS, nil)
+		opts, err := parsePollOptions(interaction, i18n)
+		if err != nil {
+			t.Fatalf("parsePollOptions() error = %v", err)
+		}
+		if opts.Title != i18n.DefaultTitle {
+			t.Errorf("Title = %q, want default %q", opts.Title, i18n.DefaultTitle)
+		}
+	})
+
+	t.Run("title is used as-is when given", func(t *testing.T) {
+		interaction := newCommandInteraction(discordgo.EnglishUS, []*discordgo.ApplicationCommandInteractionDataOption{
+			stringOpt("title", "My Poll"),
+		})
+		opts, err := parsePollOptions(interaction, i18n)
+		if err != nil {
+			t.Fatalf("parsePollOptions() error = %v", err)
+		}
+		if opts.Title != "My Poll" {
+			t.Errorf("Title = %q, want %q", opts.Title, "My Poll")
+		}
+	})
+
+	t.Run("days defaults to 7 when not given", func(t *testing.T) {
+		interaction := newCommandInteraction(discordgo.EnglishUS, nil)
+		opts, err := parsePollOptions(interaction, i18n)
+		if err != nil {
+			t.Fatalf("parsePollOptions() error = %v", err)
+		}
+		if opts.NumDays != 7 {
+			t.Errorf("NumDays = %d, want 7", opts.NumDays)
+		}
+	})
+
+	daysClampTests := []struct {
+		name  string
+		given int
+		want  int
+	}{
+		{"below minimum is clamped up to 2", 1, 2},
+		{"above maximum is clamped down to 7", 9, 7},
+		{"within range is kept as-is", 4, 4},
+	}
+	for _, tt := range daysClampTests {
+		t.Run(tt.name, func(t *testing.T) {
+			interaction := newCommandInteraction(discordgo.EnglishUS, []*discordgo.ApplicationCommandInteractionDataOption{
+				intOpt("days", tt.given),
+			})
+			opts, err := parsePollOptions(interaction, i18n)
+			if err != nil {
+				t.Fatalf("parsePollOptions() error = %v", err)
+			}
+			if opts.NumDays != tt.want {
+				t.Errorf("NumDays = %d, want %d", opts.NumDays, tt.want)
+			}
+		})
+	}
+
+	t.Run("start defaults to today at local midnight when no start-date given", func(t *testing.T) {
+		timezone, err := GetTimeZone(discordgo.EnglishUS)
+		if err != nil {
+			t.Fatalf("GetTimeZone() error = %v", err)
+		}
+		now := time.Now().In(timezone)
+		wantStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, timezone)
+
+		interaction := newCommandInteraction(discordgo.EnglishUS, nil)
+		opts, err := parsePollOptions(interaction, i18n)
+		if err != nil {
+			t.Fatalf("parsePollOptions() error = %v", err)
+		}
+		if !opts.Start.Equal(wantStart) {
+			t.Errorf("Start = %v, want %v", opts.Start, wantStart)
+		}
+	})
+
+	t.Run("unrecognized error from GetTimeZone is returned", func(t *testing.T) {
+		// GetTimeZone only special-cases discordgo.Japanese and otherwise
+		// falls back to time.Local without error, so parsePollOptions
+		// currently has no locale that reaches its error branch; this test
+		// documents that GetTimeZone never errors for the locales in use.
+		interaction := newCommandInteraction(discordgo.German, nil)
+		_, err := parsePollOptions(interaction, i18n)
+		if err != nil {
+			t.Fatalf("parsePollOptions() error = %v, want nil", err)
+		}
+	})
+}
+
+func TestBuildMessageURL(t *testing.T) {
+	got := buildMessageURL("guild1", "channel1", "message1")
+	want := "https://discord.com/channels/guild1/channel1/message1"
+	if got != want {
+		t.Errorf("buildMessageURL() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildEventURL(t *testing.T) {
+	got := buildEventURL("guild1", "event1")
+	want := "https://discord.com/events/guild1/event1"
+	if got != want {
+		t.Errorf("buildEventURL() = %q, want %q", got, want)
+	}
+}
+
+func TestEventStartTime(t *testing.T) {
+	start := time.Date(2026, time.August, 21, 9, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		numDays int
+		want    time.Time
+	}{
+		{
+			name:    "single day event starts at midnight of that day",
+			numDays: 1,
+			want:    time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "multi-day event starts at midnight of the final candidate day",
+			numDays: 3,
+			want:    time.Date(2026, time.August, 23, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := eventStartTime(start, tt.numDays)
+			if !got.Equal(tt.want) {
+				t.Errorf("eventStartTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveEventStartTime(t *testing.T) {
+	start := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+
+	t.Run("future midnight is kept as-is", func(t *testing.T) {
+		now := time.Date(2026, time.August, 20, 12, 0, 0, 0, time.UTC)
+		got := resolveEventStartTime(start, 3, now)
+		want := eventStartTime(start, 3) // 2026-08-23 midnight, still in the future
+		if !got.Equal(want) {
+			t.Errorf("resolveEventStartTime() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("already-past midnight is bumped to now+1 minute", func(t *testing.T) {
+		// eventStartTime(start, 1) is 2026-08-21 00:00, which has already
+		// passed relative to "now" below.
+		now := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+		got := resolveEventStartTime(start, 1, now)
+		want := now.Add(1 * time.Minute)
+		if !got.Equal(want) {
+			t.Errorf("resolveEventStartTime() = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestClampPollDurationToEvent(t *testing.T) {
+	eventStart := time.Date(2026, time.August, 25, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		durationHours int
+		now           time.Time
+		want          int
+	}{
+		{
+			name:          "duration within the remaining time is kept as-is",
+			durationHours: 24,
+			now:           time.Date(2026, time.August, 20, 0, 0, 0, 0, time.UTC), // 120h remaining
+			want:          24,
+		},
+		{
+			name:          "duration longer than the remaining time is clamped down",
+			durationHours: 240,
+			now:           time.Date(2026, time.August, 20, 0, 0, 0, 0, time.UTC), // 120h remaining
+			want:          120,
+		},
+		{
+			name:          "remaining time below the minimum floors to minPollDurationHours",
+			durationHours: 24,
+			now:           time.Date(2026, time.August, 24, 23, 30, 0, 0, time.UTC), // 0.5h remaining
+			want:          minPollDurationHours,
+		},
+		{
+			name:          "event start already passed floors to minPollDurationHours",
+			durationHours: 24,
+			now:           time.Date(2026, time.August, 26, 0, 0, 0, 0, time.UTC), // negative remaining
+			want:          minPollDurationHours,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clampPollDurationToEvent(tt.durationHours, eventStart, tt.now)
+			if got != tt.want {
+				t.Errorf("clampPollDurationToEvent() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/app/poll/poll_test.go
+++ b/app/poll/poll_test.go
@@ -1,6 +1,7 @@
 package poll
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -373,4 +374,90 @@ func TestClampPollDurationToEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildGuildScheduledEventParams(t *testing.T) {
+	i18n := I18n{VotingPeriod: "(V)", PollMessage: "Msg"}
+	start := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+	numDays := 3
+	messageURL := "https://discord.com/channels/guild-1/channel-1/message-1"
+	eventStart := time.Date(2026, time.August, 23, 9, 0, 0, 0, time.UTC)
+
+	params := buildGuildScheduledEventParams(i18n, start, numDays, "Test", messageURL, eventStart)
+
+	if params.Name != "(V)Test" {
+		t.Errorf("Name = %q, want %q", params.Name, "(V)Test")
+	}
+	wantDescription := "Msg: " + messageURL
+	if params.Description != wantDescription {
+		t.Errorf("Description = %q, want %q", params.Description, wantDescription)
+	}
+	if params.ScheduledStartTime == nil || !params.ScheduledStartTime.Equal(eventStart) {
+		t.Errorf("ScheduledStartTime = %v, want %v", params.ScheduledStartTime, eventStart)
+	}
+	// The final candidate day is Aug 21 + 2 days = Aug 23; the event should
+	// run through the end of that day.
+	wantEnd := time.Date(2026, time.August, 23, 23, 59, 59, 0, time.UTC)
+	if params.ScheduledEndTime == nil || !params.ScheduledEndTime.Equal(wantEnd) {
+		t.Errorf("ScheduledEndTime = %v, want %v", params.ScheduledEndTime, wantEnd)
+	}
+	if params.PrivacyLevel != discordgo.GuildScheduledEventPrivacyLevelGuildOnly {
+		t.Errorf("PrivacyLevel = %v, want %v", params.PrivacyLevel, discordgo.GuildScheduledEventPrivacyLevelGuildOnly)
+	}
+	if params.EntityType != discordgo.GuildScheduledEventEntityTypeExternal {
+		t.Errorf("EntityType = %v, want %v", params.EntityType, discordgo.GuildScheduledEventEntityTypeExternal)
+	}
+	if params.EntityMetadata == nil || params.EntityMetadata.Location != messageURL {
+		t.Errorf("EntityMetadata.Location = %v, want %q", params.EntityMetadata, messageURL)
+	}
+
+	t.Run("truncates a long title to Discord's event name limit", func(t *testing.T) {
+		longTitle := ""
+		for i := 0; i < discordEventNameMaxLength+10; i++ {
+			longTitle += "a"
+		}
+		params := buildGuildScheduledEventParams(i18n, start, numDays, longTitle, messageURL, eventStart)
+		if len([]rune(params.Name)) != discordEventNameMaxLength {
+			t.Errorf("Name length = %d, want %d", len([]rune(params.Name)), discordEventNameMaxLength)
+		}
+	})
+}
+
+func TestCreateScheduledEvent(t *testing.T) {
+	i18n := I18n{VotingPeriod: "(V)", PollMessage: "Msg"}
+	start := time.Date(2026, time.August, 21, 0, 0, 0, 0, time.UTC)
+	eventStart := time.Date(2026, time.August, 23, 0, 0, 0, 0, time.UTC)
+	messageURL := "https://discord.com/channels/guild-1/channel-1/message-1"
+
+	t.Run("delegates to GuildScheduledEventCreate with the built params and returns its result", func(t *testing.T) {
+		fake := &fakePollSession{guildScheduledEventCreateEvent: &discordgo.GuildScheduledEvent{ID: "evt-42"}}
+
+		got, err := createScheduledEvent(fake, "guild-1", i18n, start, 3, "Test", messageURL, eventStart)
+		if err != nil {
+			t.Fatalf("createScheduledEvent() error = %v", err)
+		}
+		if got.ID != "evt-42" {
+			t.Errorf("returned event ID = %q, want %q", got.ID, "evt-42")
+		}
+		if len(fake.guildScheduledEventCreateCalls) != 1 {
+			t.Fatalf("GuildScheduledEventCreate called %d times, want 1", len(fake.guildScheduledEventCreateCalls))
+		}
+		call := fake.guildScheduledEventCreateCalls[0]
+		if call.guildID != "guild-1" {
+			t.Errorf("guildID = %q, want %q", call.guildID, "guild-1")
+		}
+		if call.params.Name != "(V)Test" {
+			t.Errorf("params.Name = %q, want %q", call.params.Name, "(V)Test")
+		}
+	})
+
+	t.Run("propagates the error from GuildScheduledEventCreate", func(t *testing.T) {
+		wantErr := errors.New("event create failed")
+		fake := &fakePollSession{guildScheduledEventCreateErr: wantErr}
+
+		_, err := createScheduledEvent(fake, "guild-1", i18n, start, 3, "Test", messageURL, eventStart)
+		if err != wantErr {
+			t.Errorf("createScheduledEvent() error = %v, want %v", err, wantErr)
+		}
+	})
 }

--- a/app/poll/session.go
+++ b/app/poll/session.go
@@ -1,0 +1,14 @@
+package poll
+
+import "github.com/bwmarrin/discordgo"
+
+// pollSession is the subset of *discordgo.Session's API that NativePoll and
+// createScheduledEvent depend on. Depending on this narrow interface instead
+// of the concrete session lets tests substitute a fake implementation
+// instead of talking to Discord.
+type pollSession interface {
+	InteractionRespond(interaction *discordgo.Interaction, resp *discordgo.InteractionResponse, options ...discordgo.RequestOption) error
+	InteractionResponse(interaction *discordgo.Interaction, options ...discordgo.RequestOption) (*discordgo.Message, error)
+	FollowupMessageCreate(interaction *discordgo.Interaction, wait bool, data *discordgo.WebhookParams, options ...discordgo.RequestOption) (*discordgo.Message, error)
+	GuildScheduledEventCreate(guildID string, event *discordgo.GuildScheduledEventParams, options ...discordgo.RequestOption) (*discordgo.GuildScheduledEvent, error)
+}

--- a/app/poll/util_test.go
+++ b/app/poll/util_test.go
@@ -9,25 +9,30 @@ import (
 )
 
 func TestGetTimeZone(t *testing.T) {
-	tests := []struct {
-		name     string
-		locale   discordgo.Locale
-		wantName string
-	}{
-		{"japanese locale maps to Asia/Tokyo", discordgo.Japanese, "Asia/Tokyo"},
-		{"unknown locale falls back to time.Local", discordgo.EnglishUS, time.Local.String()},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetTimeZone(tt.locale)
-			if err != nil {
-				t.Fatalf("GetTimeZone(%v) returned error: %v", tt.locale, err)
-			}
-			if got.String() != tt.wantName {
-				t.Errorf("GetTimeZone(%v) = %v, want %v", tt.locale, got.String(), tt.wantName)
-			}
-		})
-	}
+	t.Run("japanese locale maps to Asia/Tokyo", func(t *testing.T) {
+		got, err := GetTimeZone(discordgo.Japanese)
+		if err != nil {
+			t.Fatalf("GetTimeZone(Japanese) returned error: %v", err)
+		}
+		if got.String() != "Asia/Tokyo" {
+			t.Errorf("GetTimeZone(Japanese) = %v, want Asia/Tokyo", got.String())
+		}
+	})
+
+	t.Run("unknown locale falls back to the process's time.Local", func(t *testing.T) {
+		// Compared by identity, not by name: time.Local and time.UTC are
+		// always distinct *Location values, so this catches the fallback
+		// ever changing to a different fixed zone even in an environment
+		// (e.g. CI, which is often TZ=UTC) where the two would otherwise
+		// coincidentally have the same name.
+		got, err := GetTimeZone(discordgo.EnglishUS)
+		if err != nil {
+			t.Fatalf("GetTimeZone(EnglishUS) returned error: %v", err)
+		}
+		if got != time.Local {
+			t.Errorf("GetTimeZone(EnglishUS) = %v, want time.Local", got)
+		}
+	})
 }
 
 func TestGetWeekdays(t *testing.T) {

--- a/app/poll/util_test.go
+++ b/app/poll/util_test.go
@@ -1,0 +1,186 @@
+package poll
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestGetTimeZone(t *testing.T) {
+	tests := []struct {
+		name     string
+		locale   discordgo.Locale
+		wantName string
+	}{
+		{"japanese locale maps to Asia/Tokyo", discordgo.Japanese, "Asia/Tokyo"},
+		{"unknown locale falls back to time.Local", discordgo.EnglishUS, time.Local.String()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetTimeZone(tt.locale)
+			if err != nil {
+				t.Fatalf("GetTimeZone(%v) returned error: %v", tt.locale, err)
+			}
+			if got.String() != tt.wantName {
+				t.Errorf("GetTimeZone(%v) = %v, want %v", tt.locale, got.String(), tt.wantName)
+			}
+		})
+	}
+}
+
+func TestGetWeekdays(t *testing.T) {
+	tests := []struct {
+		name   string
+		locale discordgo.Locale
+		want   []string
+	}{
+		{"english", discordgo.EnglishUS, []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}},
+		{"japanese", discordgo.Japanese, []string{"日", "月", "火", "水", "木", "金", "土"}},
+		{"unknown locale falls back to english", discordgo.German, []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getWeekdays(tt.locale)
+			if len(got) != len(tt.want) {
+				t.Fatalf("getWeekdays(%v) = %v, want %v", tt.locale, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("getWeekdays(%v)[%d] = %q, want %q", tt.locale, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetAbsence(t *testing.T) {
+	tests := []struct {
+		name   string
+		locale discordgo.Locale
+		want   string
+	}{
+		{"english", discordgo.EnglishUS, "Absence"},
+		{"japanese", discordgo.Japanese, "欠席"},
+		{"unknown locale falls back to english", discordgo.German, "Absence"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAbsence(tt.locale); got != tt.want {
+				t.Errorf("getAbsence(%v) = %q, want %q", tt.locale, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetTitle(t *testing.T) {
+	tests := []struct {
+		name   string
+		locale discordgo.Locale
+		want   string
+	}{
+		{"english", discordgo.EnglishUS, "Poll"},
+		{"japanese", discordgo.Japanese, "投票"},
+		{"unknown locale falls back to english", discordgo.German, "Poll"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getTitle(tt.locale); got != tt.want {
+				t.Errorf("getTitle(%v) = %q, want %q", tt.locale, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetVotingPeriod(t *testing.T) {
+	tests := []struct {
+		name   string
+		locale discordgo.Locale
+		want   string
+	}{
+		{"english", discordgo.EnglishUS, "(🗳️Voting)"},
+		{"japanese", discordgo.Japanese, "(🗳️投票期間中)"},
+		{"unknown locale falls back to english", discordgo.German, "(🗳️Voting)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getVotingPeriod(tt.locale); got != tt.want {
+				t.Errorf("getVotingPeriod(%v) = %q, want %q", tt.locale, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPollMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		locale discordgo.Locale
+		want   string
+	}{
+		{"english", discordgo.EnglishUS, "Poll message"},
+		{"japanese", discordgo.Japanese, "投票メッセージ"},
+		{"unknown locale falls back to english", discordgo.German, "Poll message"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getPollMessage(tt.locale); got != tt.want {
+				t.Errorf("getPollMessage(%v) = %q, want %q", tt.locale, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetI18n(t *testing.T) {
+	got := GetI18n(discordgo.Japanese)
+	want := I18n{
+		Weekdays:     []string{"日", "月", "火", "水", "木", "金", "土"},
+		Absence:      "欠席",
+		DefaultTitle: "投票",
+		VotingPeriod: "(🗳️投票期間中)",
+		PollMessage:  "投票メッセージ",
+	}
+	if got.Absence != want.Absence || got.DefaultTitle != want.DefaultTitle ||
+		got.VotingPeriod != want.VotingPeriod || got.PollMessage != want.PollMessage {
+		t.Fatalf("GetI18n(Japanese) = %+v, want %+v", got, want)
+	}
+	if strings.Join(got.Weekdays, ",") != strings.Join(want.Weekdays, ",") {
+		t.Errorf("GetI18n(Japanese).Weekdays = %v, want %v", got.Weekdays, want.Weekdays)
+	}
+}
+
+func TestFloatPtr(t *testing.T) {
+	got := FloatPtr(3.5)
+	if got == nil {
+		t.Fatal("FloatPtr(3.5) returned nil")
+	}
+	if *got != 3.5 {
+		t.Errorf("*FloatPtr(3.5) = %v, want 3.5", *got)
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"shorter than max is untouched", "hello", 10, "hello"},
+		{"exactly at max is untouched", "hello", 5, "hello"},
+		{"ascii longer than max is truncated", "hello world", 5, "hello"},
+		// truncateRunes must count runes, not bytes: each of these Japanese
+		// characters is 3 bytes in UTF-8, so a naive byte-slice truncation
+		// would split a rune in half and corrupt the string.
+		{"multi-byte string is truncated by rune count, not bytes", "投票期間中です", 3, "投票期"},
+		{"multi-byte string shorter than max is untouched", "投票", 5, "投票"},
+		{"maxLen zero yields empty string", "hello", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateRunes(tt.s, tt.maxLen); got != tt.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
- AIによるコーディングの過程および成果物のレビューにおける評価基準を明確化することを目的にユニットテストを作成
- およびCIでのテスト実行を追加

## 対象外
- poll(classic)系メソッド: メンテしないため
- ハンドラー系メソッド: 実セッションを使うため

## 観点
- 対象外メソッドが適切か
- 抽出したメソッドが適切か

## その他
- なお、Claude Code on the Webをいろいろ試行しているのでコメント欄がきたない。

---
<details>
<summary> Claude </summary>

## 概要(Claude)
Closes #55.

- `poll-classic.go`（今後メンテしない方針のため対象外。`ClassicPoll`, `AggregatePoll`, `addEventLinkToPollMessage`, `GetClassicPollCommand`）を除く、`app/poll`・`app/manage`・`app/bot` 全体にユニットテストを後追い追加しました。
- `discordgo.Session` の使用箇所を、各パッケージごとに実際に使うメソッドだけの小さなpackage-privateインターフェースに切り出しました。
  - `app/poll/session.go`: `pollSession`（`InteractionRespond`/`InteractionResponse`/`FollowupMessageCreate`/`GuildScheduledEventCreate`）
  - `app/manage/session.go`: `commandSession`（`ApplicationCommandCreate`/`ApplicationCommands`/`ApplicationCommandDelete`）
  - `*discordgo.Session` は元々これらのメソッドを持つため、既存の呼び出し側（`bot.go` など）はほぼ変更不要です。ただし `session.State.User.ID`（Botの自分自身のユーザーID）は `*discordgo.Session` のフィールドでインターフェース化できないため、`manage.Register`/`Delete` は `appID string` を明示的な引数として受け取る形にし、呼び出し元の `bot.go` から渡すよう変更しています（挙動は変わりません）。
- `NativePoll`・`createScheduledEvent`・`manage.Register`/`Delete`・`bot.go` の中にあった純粋ロジック（Session呼び出しを伴わない部分）を、それぞれヘルパ/リゾルバ関数として切り出しました。挙動は変えていません。
  - `resolveStartDate` / `resolveDurationHours` — 開始日・durationの解決（デフォルト値・クランプ）
  - `buildPollAnswers` / `buildNativePollResponse` — Discordネイティブ投票の応答組み立て
  - `buildGuildScheduledEventParams` — 連携するギルドスケジュールイベントのパラメータ組み立て
  - `commandsToRegister` — 登録するスラッシュコマンド一覧
  - `resolveCommandKind` — インタラクションのコマンド名から、どのハンドラを呼ぶべきかを判定する純粋関数（discordgoの構造体にも依存しない）
- 上記により各関数は薄いオーケストレーションになり、手書きのfake（`fakePollSession`/`fakeCommandSession`。モックライブラリは未使用）でセッション呼び出しの順序・引数・エラー伝播を直接テストできるようにしています。
- `.github/workflows/test.yml` を新規追加し、プルリクエスト時に `go vet` + `go test` を実行するようにしました。既存のワークフローはDockerイメージのビルド確認のみで、`go test` は一度も実行されていませんでした。
- README に「Running Tests」セクションを追記しました。

`messageReactionAddEventHandler`/`messageReactionRemoveEventHandler`（`poll.AggregatePoll` への薄い委譲）と `Bot.Run()`（実際のセッション接続・OSシグナル待ちを含む起動シーケンスそのもの）はテスト対象外です。前者はスコープ外の `AggregatePoll` に処理を委譲するだけであり、後者は実行時I/Oそのものであるためです。

### 進め方（TDDの体でのテスト後追い作成）

対象コードは実装が先に存在するため、厳密な red-green-refactor は成立しません。そこで各関数について、実装の中身をそのまま読んでその出力をアサーションにコピーする（characterization test）のではなく、関数名・コメント・Discord側の仕様制約から「あるべき仕様」を先に言語化してテストケースを書き、その後に実装と照合する、という進め方にしました。プロダクションコードのバグは見つかりませんでした。本体側の変更は、テスト容易性のための挙動保存リファクタ（各Sessionのインターフェース化、純粋ロジックの切り出し、`time.Now()`の明示的な引数化）のみです。

## テスト計画

- [x] `cd app && go vet ./...` — 問題なし
- [x] `cd app && go test ./... -race -v` — 追加したテストはすべてpass
- [x] `gofmt -l .` — フォーマット差分なし
- [x] 本PR上で新設した `test` ワークフローがGitHub Actions上でも成功することを確認
</details>



